### PR TITLE
Fix a typo made with the spelling of "breadth"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ To check all the available methods to manipulate a Graph, see the [GoDoc](http:/
 ### Search:
 * Dijkstra (uniform cost search)
 * A* (best-first search with heuristic)
-* Breath-first search
+* Breadth-first search
 * Depth-first search
 
 For the shortest path implementation, a generic `Search` function is provided, which takes the desired `SearchAlgorithm` to be used as a parameter:
 
 ```
 path, err := grapho.Search(graph, 1, 8, grapho.Dijkstra, nil)
-path, err := grapho.Search(graph, 1, 9, grapho.BreathFirstSearch, nil)
+path, err := grapho.Search(graph, 1, 9, grapho.BreadthFirstSearch, nil)
 ...
 
 ```

--- a/search.go
+++ b/search.go
@@ -9,7 +9,7 @@ import (
 type SearchAlgorithm uint
 
 const (
-	BreathFirstSearch SearchAlgorithm = iota
+	BreadthFirstSearch SearchAlgorithm = iota
 	DepthFirstSearch
 	Dijkstra
 	Astar
@@ -85,7 +85,7 @@ func traverse(graph *Graph, start, goal uint64, algo SearchAlgorithm, heuristic 
 	// Initialize the open set, according to the type of search passed in
 	var openSet OpenSet
 	switch algo {
-	case BreathFirstSearch:
+	case BreadthFirstSearch:
 		openSet = &OpenQueue{container.NewQueue()} // FIFO approach to expand nodes
 	case DepthFirstSearch:
 		openSet = &OpenStack{container.NewStack()} // LIFO approach to expand nodes

--- a/search_test.go
+++ b/search_test.go
@@ -30,8 +30,8 @@ func TestSearch(t *testing.T) {
 	testAstar(t, sampleDiGraph())
 
 	// BFS
-	testBreathFirstSearch(t, sampleGraph())
-	testBreathFirstSearch(t, sampleDiGraph())
+	testBreadthFirstSearch(t, sampleGraph())
+	testBreadthFirstSearch(t, sampleDiGraph())
 
 	// DFS
 	testDepthFirstSearch(t, sampleGraph())
@@ -72,11 +72,11 @@ func testAstar(t *testing.T, g *Graph) {
 	}
 }
 
-// testBreathFirstSearch tests BreathFirstSearch algorithm with the given graph
-func testBreathFirstSearch(t *testing.T, g *Graph) {
-	path, err := Search(g, 1, 9, BreathFirstSearch, nil)
+// testBreadthFirstSearch tests BreadthFirstSearch algorithm with the given graph
+func testBreadthFirstSearch(t *testing.T, g *Graph) {
+	path, err := Search(g, 1, 9, BreadthFirstSearch, nil)
 	if err != nil {
-		t.Fatalf("BreathFirstSearch: %v", err)
+		t.Fatalf("BreadthFirstSearch: %v", err)
 	}
 
 	expected := []uint64{1, 2, 4, 7, 9}


### PR DESCRIPTION
There is a bad spelling of word "breadth" that was written as "breath".
